### PR TITLE
Add @Param processing, create synth, beans as needed.

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/omnifaces/it/CdiParamBean.java
+++ b/integration-tests/src/main/java/io/quarkiverse/omnifaces/it/CdiParamBean.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.omnifaces.it;
+
+import static org.omnifaces.util.Faces.isValidationFailed;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Date;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.FacesException;
+import jakarta.faces.convert.DateTimeConverter;
+import jakarta.faces.validator.LengthValidator;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.validation.constraints.NotNull;
+
+import org.omnifaces.cdi.Param;
+import org.omnifaces.cdi.param.Attribute;
+import org.omnifaces.util.Messages;
+
+@Named
+@RequestScoped
+public class CdiParamBean {
+
+    // Like <f:viewParam name="text1" value="#{bean.text1}" required="true">
+    @Inject
+    @Param(required = true)
+    String text1;
+
+    // Like <f:viewParam name="text2" value="#{bean.text2}" validatorMessage="..."><f:validateLength minimum="3">
+    @Inject
+    @Param(validatorClasses = LengthValidator.class, validatorAttributes = @Attribute(name = "minimum", value = "3"), validatorMessage = "{1}: Value is too too small! Please enter a minimum of 3 characters.")
+    String text2;
+
+    // Multi-valued parameters are not possible with <f:viewParam>; using JSR303 bean validation via the @NotNull constraint.
+    @Inject
+    @Param
+    @NotNull(message = "{0} is required")
+    List<String> text3;
+
+    // Like <f:viewParam name="number" value="#{bean.number}"> using implicit Faces integer converter.
+    @Param
+    Integer number;
+
+    // Like <f:viewParam name="date" value="#{bean.date}" converterMessage="..."><f:convertDateTime pattern="yyyyMMdd">
+    @Inject
+    @Param(converterClass = DateTimeConverter.class, converterAttributes = {
+            @Attribute(name = "pattern", value = "yyyyMMdd") }, converterMessage = "{1}: \"{0}\" is not the date format we had in mind! Please use the format yyyyMMdd.")
+    Date date;
+
+    private String result;
+
+    @PostConstruct
+    public void init() {
+        if (isValidationFailed()) {
+            result = "Validation has failed!";
+            return;
+        }
+
+        result = String.format("You entered text1 '%s', text2 '%s', text3 '%s', number '%d', date '%5$tY%5$tm%5$td'", text1,
+                text2, text3, number, date);
+
+        Messages.addGlobalInfo("Yes, no validation errors!");
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T copy(T source) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        T copy = null;
+
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(source);
+        } catch (IOException e) {
+            throw new FacesException(e);
+        }
+
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            copy = (T) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new FacesException(e);
+        }
+
+        return copy;
+    }
+
+}

--- a/runtime/src/main/java/io/quarkus/omnifaces/runtime/ParamBeanCreator.java
+++ b/runtime/src/main/java/io/quarkus/omnifaces/runtime/ParamBeanCreator.java
@@ -1,0 +1,23 @@
+package io.quarkus.omnifaces.runtime;
+
+import jakarta.enterprise.inject.spi.InjectionPoint;
+
+import org.omnifaces.cdi.param.ParamProducer;
+import org.omnifaces.cdi.param.ParamValue;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.SyntheticCreationalContext;
+
+public class ParamBeanCreator implements BeanCreator<Object> {
+
+    @Override
+    public Object create(SyntheticCreationalContext<Object> context) {
+        InjectionPoint injectionPoint = context.getInjectedReference(InjectionPoint.class);
+        if (injectionPoint == null) {
+            throw new IllegalStateException("No current injection point found");
+        }
+        // delegate to the original producer
+        ParamValue<?> paramValue = new ParamProducer().produce(injectionPoint);
+        return paramValue.getValue();
+    }
+}


### PR DESCRIPTION
@melloware Here's what I've been talking about.

I also realized you don't even need to add the `@Inject` to `@Param` fields that don't have it - Quarkus will do this for you automatically. It is a [non-standard feature](https://quarkus.io/guides/cdi-reference#qualified-injected-fields) which can be turned off optionally but there's no reason to do that, really (apart from when you run CDI TCKs which have tests expecting failure in such a case). Therefore, I have omitted that build step from this PR.