### PR TITLE
Activate OmniFaces push at build time

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/omnifaces/deployment/OmnifacesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/omnifaces/deployment/OmnifacesProcessor.java
@@ -12,6 +12,7 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
@@ -176,6 +177,17 @@ class OmnifacesProcessor {
                         }
                     });
         }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    void activatePush(OmniFacesRecorder recorder, CombinedIndexBuildItem combinedIndex) {
+        combinedIndex.getIndex()
+                .getAnnotations(DotName.createSimple(Push.class.getName()))
+                .forEach(annotation -> {
+                    AnnotationValue type = annotation.value("type");
+                    recorder.activatePush(type == null ? Push.Type.SOCKET.name() : type.asEnum());
+                });
     }
 
     @BuildStep

--- a/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushActivationAssert.java
+++ b/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushActivationAssert.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.omnifaces.test;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Asserts whether the SSE endpoint got registered. It answers an unknown channel with an HTTP 200 close event rather
+ * than a container 404, so the status code tells whether it is mapped at all.
+ * <p>
+ * The web socket endpoint has no such tell, as a plain GET to it yields a 404 either way, so these tests can only
+ * observe that a {@code @Push} type does or does not activate SSE. That the default type activates the web socket
+ * endpoint is covered by the OmniFaces integration tests.
+ */
+final class PushActivationAssert {
+
+    private PushActivationAssert() {
+        throw new AssertionError();
+    }
+
+    static void assertSseEndpointRegistered(URL baseUrl, boolean expected) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl + "omnifaces.sse/unknownChannel")).build();
+        HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (expected) {
+            Assertions.assertEquals(200, response.statusCode(), "SSE endpoint must be registered");
+            Assertions.assertTrue(response.body().contains("event: close"), "SSE endpoint must answer with a close event");
+        } else {
+            Assertions.assertEquals(404, response.statusCode(), "SSE endpoint must not be registered");
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushNotificationActivationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushNotificationActivationTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.omnifaces.test;
+
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.omnifaces.cdi.Push;
+import org.omnifaces.cdi.PushContext;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+/**
+ * Verifies that a {@code @Push} injection point of type NOTIFICATION activates the associated endpoint, even though ArC does
+ * not
+ * run the CDI portable extension which OmniFaces itself relies on to detect them.
+ */
+public class PushNotificationActivationTest {
+
+    @ApplicationScoped
+    public static class PushBean {
+
+        @Inject
+        @Push(type = Push.Type.NOTIFICATION)
+        PushContext push;
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(PushBean.class, PushActivationAssert.class));
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    @Test
+    public void testSseEndpointRegistration() throws Exception {
+        PushActivationAssert.assertSseEndpointRegistered(baseUrl, true);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushSocketActivationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushSocketActivationTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.omnifaces.test;
+
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.omnifaces.cdi.Push;
+import org.omnifaces.cdi.PushContext;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+/**
+ * Verifies that a {@code @Push} injection point of the default type activates the associated endpoint, even though ArC does not
+ * run the CDI portable extension which OmniFaces itself relies on to detect them.
+ */
+public class PushSocketActivationTest {
+
+    @ApplicationScoped
+    public static class PushBean {
+
+        @Inject
+        @Push
+        PushContext push;
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(PushBean.class, PushActivationAssert.class));
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    @Test
+    public void testSseEndpointRegistration() throws Exception {
+        PushActivationAssert.assertSseEndpointRegistered(baseUrl, false);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushSseActivationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/omnifaces/test/PushSseActivationTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.omnifaces.test;
+
+import java.net.URL;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.omnifaces.cdi.Push;
+import org.omnifaces.cdi.PushContext;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+/**
+ * Verifies that a {@code @Push} injection point of type SSE activates the associated endpoint, even though ArC does not
+ * run the CDI portable extension which OmniFaces itself relies on to detect them.
+ */
+public class PushSseActivationTest {
+
+    @ApplicationScoped
+    public static class PushBean {
+
+        @Inject
+        @Push(type = Push.Type.SSE)
+        PushContext push;
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(PushBean.class, PushActivationAssert.class));
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    @Test
+    public void testSseEndpointRegistration() throws Exception {
+        PushActivationAssert.assertSseEndpointRegistered(baseUrl, true);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <jakarta-security.version>4.0.0</jakarta-security.version>
         <quarkus.version>3.33.1</quarkus.version>
         <myfaces.version>4.1.3</myfaces.version>
-        <omnifaces.version>5.4.3</omnifaces.version>
+        <omnifaces.version>5.4.4</omnifaces.version>
 		<compiler-plugin.version>3.15.0</compiler-plugin.version>
     </properties>
     <dependencyManagement>

--- a/runtime/src/main/java/io/quarkus/omnifaces/runtime/OmniFacesRecorder.java
+++ b/runtime/src/main/java/io/quarkus/omnifaces/runtime/OmniFacesRecorder.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.myfaces.util.lang.ClassUtils;
+import org.omnifaces.cdi.Push;
+import org.omnifaces.cdi.push.PushExtension;
 
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -39,6 +41,10 @@ public class OmniFacesRecorder {
 
         Set<Class<?>> classes = ANNOTATED_CLASSES.computeIfAbsent(annotation, $ -> new HashSet<>());
         classes.add(clazz);
+    }
+
+    public void activatePush(String type) {
+        PushExtension.activate(Push.Type.valueOf(type));
     }
 
 }


### PR DESCRIPTION
OmniFaces detects `@Inject @Push PushContext` injection points with a CDI portable extension (`PushExtension`), which ArC does not run. On Quarkus that means `PushExtension.isSocketActivated()` and `isSseActivated()` are always false, so neither endpoint gets registered at startup:

- `<o:socket>` only works if the application sets the `org.omnifaces.SOCKET_ENDPOINT_ENABLED` context param, which is the escape hatch `Socket.registerEndpointIfNecessary` still honours;
- `<o:sse>` and `<o:notification>` have no such escape hatch and fail outright with *"SSE endpoint is not registered"*.

This adds a `@Record(STATIC_INIT)` build step which scans the combined index for `@Push`, reads its `type` (defaulting to `SOCKET`), and calls the new `PushExtension#activate(Push.Type)` from the recorder. STATIC_INIT runs before the servlet context is initialized, which is the deadline for endpoint registration.

Requires OmniFaces 5.4.4, so `omnifaces.version` is bumped accordingly.

### Verified

Covered by `PushSseActivationTest`, `PushNotificationActivationTest` and `PushSocketActivationTest`, which boot an application with the respective `@Push` injection point and assert whether the SSE endpoint answers. Disabling the build step turns the two positive ones red.

The web socket endpoint has no equivalent HTTP tell — a plain GET to `omnifaces.socket/...` yields a 404 whether or not it is registered — so `PushSocketActivationTest` can only assert that the default type does *not* activate SSE. That the default type does activate the web socket endpoint is covered by the OmniFaces integration tests, where `SocketIT` on the `quarkus-myfaces` profile goes from failing with *"o:socket endpoint is not enabled"* to opening sockets.

Also ran the OmniFaces integration test suite on the `quarkus-myfaces` profile with this extension pinned locally: `SseSessionBindingIT` and `SseMaxSessionsIT` pass where they previously failed at deployment, and `SocketSessionBindingIT` and `SocketMaxSessionsIT` keep passing.

Ref https://github.com/omnifaces/omnifaces/issues/976

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5)
